### PR TITLE
Dependency ibrowse: v4.2.2 at hex.pm

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule CellTool.Mixfile do
                 {:earmark, "~> 0.1", only: :dev},
                 {:ex_doc, "~> 0.7", only: :dev},
 		{:exjsx, "~> 3.0.0" },
-		{:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.0"},
+		{:ibrowse, "~> 4.2.2"},
 		{:httpotion, "~> 0.2.4"},
                 {:conform, github: "bitwalker/conform"}
 	]


### PR DESCRIPTION
Resolves the following build issue when running mix escript.build

==> ibrowse (compile)
Compiling src/ibrowse_lib.erl failed:
src/ibrowse_lib.erl:371: erlang:now/0: Deprecated BIF. See the "Time and
Time Correction in Erlang" chapter of the ERTS User's Guide for more
information.
