### PR TITLE
Dependency Conform in SsdpClient.ssdp_st/0

### DIFF
--- a/lib/ssdp_client.ex
+++ b/lib/ssdp_client.ex
@@ -60,9 +60,15 @@ defmodule SsdpClient do
 
   defp ssdp_st do
     path = Path.expand "~/.cell/cell.conf"
-    case Conform.Parse.file(path) do
-      {:error, _} -> @default_ssdp_st
-      conf ->
+    conf = try do
+      Conform.Parse.file(path) 
+    rescue
+      err -> {:error, err}
+    end
+    case conf do
+      {:error, _} ->
+        @default_ssdp_st
+      {:ok, conf} ->
         case :proplists.get_value(['cell','ssdp_st'], conf) do
           :undefined -> @default_ssdp_st
           st -> st

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule CellTool.Mixfile do
 		{:exjsx, "~> 3.0.0" },
 		{:ibrowse, github: "cmullaparthi/ibrowse", tag: "v4.1.0"},
 		{:httpotion, "~> 0.2.4"},
-                {:conform, github: "bitwalker/conform"}
+                {:conform, "~> 1.0.0-rc8"}
 	]
 
   defp version do


### PR DESCRIPTION
Use Conform at hex.pm v1.0.0-rc8 instead of github

On invoking `cell list` I hit an error which conform raises internally
when file is missing.

Instead of returning an {:error, :enoent} as the
ssdp_st/0 expected, it was actually raising.

The upgrade made no difference to this error case, however it changed
the success case slightly, returning a tuple like {:ok, conf}.

I've adapted the function to handle if the file exists or not correctly
in each case without crashing, using the latest conform.
